### PR TITLE
Fixed problem when used with webpack-dev-server

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ module.exports = function (content) {
       return cb(err);
     }
     var urls = {};
-    for (var i in formats) {
+    for (var i = 0; i < formats.length; i++) {
       var format = formats[i];
       var filename = config.fileName || params.fileName || '[chunkhash]-[fontname].[ext]';
       var chunkHash = filename.indexOf('[chunkhash]') !== -1


### PR DESCRIPTION
Avoided for/in to enumerate an array since webpack-dev-server is using a (quite questionable) polyfill to add an ``includes`` function to ``Array.prototype`` without making it non-enumerable, and it's causing problems in webfonts-loader.